### PR TITLE
Transactional api support

### DIFF
--- a/src/SDK/Emails/BentoEmails.php
+++ b/src/SDK/Emails/BentoEmails.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace bentonow\Bento\SDK\Emails;
+
+use bentonow\Bento\SDK\BentoClient;
+class BentoEmails
+{
+    /**
+     * The Emails endpoint.
+     *
+     * @var string
+     */
+    private $_url = '/batch/emails';
+
+
+    /**
+     * The BentoClient to use.
+     *
+     * @var \bentonow\Bento\SDK\BentoClient
+     */
+    private $_client;
+
+    /**
+     * Create a new Bento Emails processor.
+     *
+     * @param \bentonow\Bento\SDK\BentoClient $client
+     * @return void
+     */
+    public function __construct(BentoClient $client)
+    {
+        $this->_client = $client;
+    }
+
+    /**
+     * Creates an email request. Requests are instant and queued into a priority queue.
+     * Takes an email array of 1 to 60 emails. Example:
+     * emails: [
+     * {
+     *  "to": "test@bentonow.com",
+     *  "from": "jesse@bentonow.com",
+     *  "subject": "Reset Password",
+     *  "html_body": "<p>Here is a link to reset your password ... {{ link }}</p>",
+     *  "transactional": true,
+     *  "personalizations": {
+     *      "link": "https://example.com/test"
+     *  }
+     * }
+     * ]
+     *
+     * @param mixed $parameters
+     * @returns mixed
+     */
+    public function createEmail($parameters)
+    {
+        $response = $this->_client->post($this->_url, [
+            'emails' => $parameters
+        ]);
+
+        $result = json_decode($response->getBody(), true);
+        return isset($result['data']) ? $result['data'] : null;
+    }
+
+}

--- a/src/SDK/Emails/BentoEmails.php
+++ b/src/SDK/Emails/BentoEmails.php
@@ -33,18 +33,19 @@ class BentoEmails
 
     /**
      * Creates an email request. Requests are instant and queued into a priority queue.
-     * Takes an email array of 1 to 60 emails. Example:
-     * emails: [
-     * {
-     *  "to": "test@bentonow.com",
-     *  "from": "jesse@bentonow.com",
-     *  "subject": "Reset Password",
-     *  "html_body": "<p>Here is a link to reset your password ... {{ link }}</p>",
-     *  "transactional": true,
-     *  "personalizations": {
-     *      "link": "https://example.com/test"
-     *  }
-     * }
+     * Transaction emails appear in email logs or under the profile of the subscriber.
+     * Takes an array of emails as an array. Minimum 1 maximum of 60 emails. Example:
+     * [
+     *  [
+     *     "to": "test@bentonow.com",
+     *     "from": "jesse@bentonow.com",
+     *     "subject": "Reset Password",
+     *     "html_body": "<p>Here is a link to reset your password ... {{ link }}</p>",
+     *     "transactional": true,
+     *     "personalizations": [
+     *         "link": "https://example.com/test"
+     *      ]
+     *  ]
      * ]
      *
      * @param mixed $parameters

--- a/src/Versions/BentoAPIV1.php
+++ b/src/Versions/BentoAPIV1.php
@@ -103,7 +103,7 @@ class BentoAPIV1
     }
 
     if ($name == 'Emails') {
-      return $this->_commands;
+      return $this->_emails;
     }
 
     if ($name == 'Experimental') {

--- a/src/Versions/BentoAPIV1.php
+++ b/src/Versions/BentoAPIV1.php
@@ -11,6 +11,7 @@ use bentonow\Bento\SDK\Fields\BentoFields;
 use bentonow\Bento\SDK\Forms\BentoForms;
 use bentonow\Bento\SDK\Subscribers\BentoSubscribers;
 use bentonow\Bento\SDK\Tags\BentoTags;
+use bentonow\Bento\SDK\Emails\BentoEmails;
 
 class BentoAPIV1
 {
@@ -35,6 +36,13 @@ class BentoAPIV1
    * @var \bentonow\Bento\SDK\Commands\BentoCommands
    */
   private $_commands;
+
+    /**
+     * The BentoEmails to use.
+     *
+     * @var \bentonow\Bento\SDK\Emails\BentoEmails
+     */
+    private $_emails;
 
   /**
    * The BentoExperimental to use.
@@ -76,6 +84,7 @@ class BentoAPIV1
     $this->_client = new BentoClient($options);
     $this->_batch = new BentoBatch($this->_client);
     $this->_commands = new BentoCommands($this->_client);
+    $this->_emails = new BentoEmails($this->_client);
     $this->_experimental = new BentoExperimental($this->_client);
     $this->_fields = new BentoFields($this->_client);
     $this->_forms = new BentoForms($this->_client);
@@ -90,6 +99,10 @@ class BentoAPIV1
     }
 
     if ($name == 'Commands') {
+      return $this->_commands;
+    }
+
+    if ($name == 'Emails') {
       return $this->_commands;
     }
 

--- a/tests/SDK/Emails/BentoEmailsTest.php
+++ b/tests/SDK/Emails/BentoEmailsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace bentonow\Bento\Tests\SDK\Commands;
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Server\Server;
+use PHPUnit\Framework\TestCase;
+use bentonow\Bento\BentoAnalytics;
+
+final class BentoEmailsTest extends TestCase
+{
+  public function setUp(): void
+  {
+    Server::start();
+
+    register_shutdown_function(static function () {
+      Server::stop();
+    });
+  }
+
+  public function tearDown(): void
+  {
+    Server::flush();
+  }
+
+  public function testCreateEmails()
+  {
+    $bento = new BentoAnalytics([
+      'authentication' => [
+        'secretKey' => '123SK',
+        'publishableKey' => '123PK',
+      ],
+      'siteUuid' => 'test',
+      'clientOptions' => [
+        'baseUrl' => Server::$url,
+      ],
+    ]);
+
+    $returnData = [
+      [
+          'results' => 1,
+          'failed' => 0,
+      ]
+    ];
+
+    Server::enqueue([
+      new Response(200, [], json_encode(['data' => $returnData]))
+    ]);
+
+    $result = $bento->V1->Emails->createEmail([
+        [
+            'to' => 'test@bentonow.com',
+            'from' => 'jesse@bentonow.com',
+            'subject' => 'Reset Password',
+            'html_body' => "<p>Here is a link to reset your password ... {{ link }}</>",
+            'transactional' => true,
+            'personalizations' => [
+                'link' => 'https://example.com/test'
+            ]
+        ]
+    ]);
+
+    $requests = Server::received();
+
+      $this->assertEquals(
+          '{"emails":[{"to":"test@bentonow.com","from":"jesse@bentonow.com","subject":"Reset Password","html_body":"<p>Here is a link to reset your password ... {{ link }}<\/>","transactional":true,"personalizations":{"link":"https:\/\/example.com\/test"}}],"site_uuid":"test"}',
+          $requests[0]->getBody()->getContents()
+      );
+
+    $this->assertEquals($returnData, $result);
+  }
+
+}


### PR DESCRIPTION
This PR adds support for the transactional api documented here: 
https://docs.bentonow.com/reference-api/create-emails

**Emails** namespace was used to match the api documentation as was the createEmail method. 

A supporting test was added matching existing testing process and asserts. 

docblocks and documentation matched with existing code for continuity in the package. 

