### PR TITLE
Handle response format change

### DIFF
--- a/src/SDK/Commands/BentoCommands.php
+++ b/src/SDK/Commands/BentoCommands.php
@@ -192,7 +192,8 @@ class BentoCommands
 
   private function _constructCommandsResult($response)
   {
-    $decodedResponse = json_decode($response->getBody(), true);
-    return isset($decodedResponse['data']) ? $decodedResponse['data'] : null;
+    $responseBody = (string) $response->getBody();
+    $decodedResponse = json_decode($responseBody, true);
+    return isset($decodedResponse) ? $decodedResponse : null;
   }
 }


### PR DESCRIPTION
The Bento API is responding without the data wrapper key when making command changes. The response validation was explicitly checking for the 'data' key and throwing an exception if it was not present. 

I removed this check and added a string cast due to an error experienced in the Lumen framework by another user.

I also changed the response check to a null value check. This prevents the need for future changes but requires users to handle response validation. 

Alternatively, we could explicitly check for the 'results' key and ensure its value is greater than 1 to confirm that at least one command was successful.